### PR TITLE
Build PDF using GitHub Actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ indent_style = space
 indent_size = 4
 charset = utf-8
 continuation_indent_size = 8
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/build-score.yml
+++ b/.github/workflows/build-score.yml
@@ -16,7 +16,7 @@ jobs:
         args: >
           --verbose
           --include=/github/workspace
-          --output=/github/workspace
+          --output=/github/workspace/silent-night
           --pdf
           silent-night.ly
     - name: Release

--- a/.github/workflows/build-score.yml
+++ b/.github/workflows/build-score.yml
@@ -6,7 +6,16 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v2
+    - name: Set ly_revision environment variable
+      run: echo "ly_revision=$(git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD)" >> $GITHUB_ENV
+    - name: Echo ly_revision
+      run: echo "${{ env.ly_revision }}"
     - name: Generate PDF music sheets
       uses: alexandre-touret/lilypond-github-action@master
       with:
-        args: -V --include=/github/workspace --pdf silent-night.ly
+        args: >
+          --verbose
+          --include=/github/workspace
+          --output=/github/workspace
+          --pdf
+          silent-night.ly

--- a/.github/workflows/build-score.yml
+++ b/.github/workflows/build-score.yml
@@ -1,0 +1,12 @@
+name: Build sheet music with LilyPond
+on: [push]
+jobs:
+  build-sheet-music:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Generate PDF music sheets
+      uses: alexandre-touret/lilypond-github-action@master
+      with:
+        args: -V --include=/github/workspace --pdf silent-night.ly

--- a/.github/workflows/build-score.yml
+++ b/.github/workflows/build-score.yml
@@ -19,3 +19,10 @@ jobs:
           --output=/github/workspace
           --pdf
           silent-night.ly
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: silent-night.pdf
+        fail_on_unmatched_files: true
+

--- a/defs.ily
+++ b/defs.ily
@@ -10,6 +10,14 @@
            (stretchability . 60))
 }
 
+revision = #(let
+    ((revision (getenv "ly_revision")))
+    (if (not revision)
+        (string-append "unknown (" (strftime "%FT%T%z" (localtime (current-time))) ")")
+        revision
+        )
+    )
+
 rit = \markup { \italic "rit." }
 
 atempo = "a tempo"

--- a/silent-night.ly
+++ b/silent-night.ly
@@ -1,6 +1,6 @@
 % SPDX-License-Identifier: Apache-2.0 OR CC-BY-4.0
 
-\version "2.22.1"
+\version "2.22.0"
 \include "defs.ily"
 
 \header {

--- a/silent-night.ly
+++ b/silent-night.ly
@@ -1,6 +1,8 @@
 % SPDX-License-Identifier: Apache-2.0 OR CC-BY-4.0
 
 \version "2.22.0"
+#(use-modules (guile-user))
+
 \include "defs.ily"
 
 \header {
@@ -9,8 +11,11 @@
     arranger = "Rune Flobakk (arr.)"
     tagline = ##f
     instrument = "Piano"
-    copyright = \markup {
-        \copyrightSign "2022 Rune Flobakk " \emdash " Licensed under " \licenseCc
+    copyright = \markup { \smaller
+        \column {
+            \center-align \line { \copyrightSign "2022 Rune Flobakk" \emdash "Licensed under" \licenseCc }
+            \center-align \line { "Revision:" \revision }
+        }
     }
 }
 


### PR DESCRIPTION
## Actions used

- [alexandre-touret/lilypond-github-action](https://github.com/alexandre-touret/lilypond-github-action) for building Lilypond score
- [softprops/action-gh-release](https://github.com/softprops/action-gh-release) for creating releases with attached PDF when pushing tags.


## TODO suggestions:
- Enable caching Lilypond Docker image, using either [actions/docker-layer-caching](https://github.com/marketplace/actions/docker-layer-caching) or the more generic [actions/cache](https://github.com/actions/cache)